### PR TITLE
Update ajax.php

### DIFF
--- a/lib/ajax.php
+++ b/lib/ajax.php
@@ -10,7 +10,7 @@
 
 // Attach to our standard script enqueue and create a localized script
 // containing needed url/nonce variables for AJAX processing.
-add_action('wp_enqueue_scripts', 'roots_ajax_scripts', 99);
+add_action('wp_enqueue_scripts', 'roots_ajax_scripts', 101);
 function roots_ajax_scripts() {
   // Setup a localized script with relevant url and nonce information.
   wp_localize_script( 'roots_scripts', 'rootsAjax', array(


### PR DESCRIPTION
In the lib/scripts the priority or the order of the wp_enqueue_sripts is 100. If lib/ajax uses priority 99, rootsAjax does not get defined. With priority 101 rootsAjax gets defined.
